### PR TITLE
'buf.write方法的参数顺序改变'

### DIFF
--- a/ByteBuffer.js
+++ b/ByteBuffer.js
@@ -252,12 +252,12 @@ var ByteBuffer = function (org_buf,offset) {
                     //前2个字节表示字符串长度
                     _org_buf['writeInt16'+_endian+'E'](_list[i].l,offset);
                     offset+=2;
-                    _org_buf.write(_list[i].d,_encoding,offset);
+                    _org_buf.write(_list[i].d, offset, _encoding);
                     offset+=_list[i].l;
                     break;
                 case Type_VString:
                     var vlen = Buffer.byteLength(_list[i].d, _encoding);//字符串实际长度
-                    _org_buf.write(_list[i].d,_encoding,offset);
+                    _org_buf.write(_list[i].d, offset, _encoding);
                     //补齐\0
                     for(var j = offset + vlen;j<offset+_list[i].l;j++){
                          _org_buf.writeUInt8(0,j);


### PR DESCRIPTION
在新版的nodejs中(我当前是6.3.1) Buffer的实例方法write的签名发生了改变,原本的buf.write方法不能用了.
详情：https://github.com/felixge/node-formidable/issues/364